### PR TITLE
Use relative file path for s:GetTargetsFromContext

### DIFF
--- a/autoload/bazel.vim
+++ b/autoload/bazel.vim
@@ -38,12 +38,13 @@ function! s:GetTargetsFromContext() abort
   endif
 
   " Assume that the current file is a source file
+  let rel_fname = <SID>PathRelativeToWsRoot(fname)
   let build_file_path = findfile("BUILD", ".;")
   let relative_path = <SID>PathRelativeToWsRoot(build_file_path)
   let package_path = fnamemodify(relative_path, ":h")
   let package_spec = "//" . package_path . "/..."
   let fmt = "$(bazel cquery --collapse_duplicate_defines --noshow_timestamps --output=starlark 'kind(rule, rdeps(%s, %s, 1))' || echo CQUERY_FAILED)"
-  return printf(fmt, package_spec, fname)
+  return printf(fmt, package_spec, rel_fname)
 endfunction
 
 function! bazel#Execute(action, ...) abort

--- a/autoload/bazel.vim
+++ b/autoload/bazel.vim
@@ -28,17 +28,15 @@ function! s:PathRelativeToWsRoot(path) abort
 endfunction
 
 function! s:GetTargetsFromContext() abort
-  let fname = expand("%")
+  let rel_fname = <SID>PathRelativeToWsRoot(fname)
 
   " Is the current file a BUILD file?
   if fnamemodify(fname, ":t") ==# "BUILD"
-    let rel_path = <SID>PathRelativeToWsRoot(fname)
-    let package_path = fnamemodify(rel_path, ":h")
+    let package_path = fnamemodify(rel_fname, ":h")
     return "//" . package_path . ":all"
   endif
 
   " Assume that the current file is a source file
-  let rel_fname = <SID>PathRelativeToWsRoot(fname)
   let build_file_path = findfile("BUILD", ".;")
   let relative_path = <SID>PathRelativeToWsRoot(build_file_path)
   let package_path = fnamemodify(relative_path, ":h")


### PR DESCRIPTION
According to https://vi.stackexchange.com/a/39795, `expand('%')` doesn't always return the relative path. This PR makes it explicit to use the relative file path to workspace similar to relative package path.

```
$ cd /path/to/project
$ vim
:edit README.md
:echo expand('%')
README.md
:edit /path/to/project/CONTRIBUTING.md
:echo expand('%')
/path/to/project/CONTRIBUTING.md
:edit ../project/LICENSE
:echo expand('%')
../project/LICENSE
```